### PR TITLE
Implementación de QR para paquetes

### DIFF
--- a/client/src/pages/PaquetesCustodia.jsx
+++ b/client/src/pages/PaquetesCustodia.jsx
@@ -4,6 +4,7 @@ import ConserjeNavbar from '../components/ConserjeNavbar.jsx'
 export default function PaquetesCustodia() {
   const [paquetes, setPaquetes] = useState([])
   const [error, setError]       = useState('')
+  const [qrImage, setQrImage]   = useState('')
 
   const API = import.meta.env.VITE_API_URL + '/api/v1/paquetes'
 
@@ -50,6 +51,17 @@ export default function PaquetesCustodia() {
     }
   }
 
+  const handleShowQr = async (id, accion) => {
+    try {
+      const res = await fetch(`${API}/${id}/qr/${accion}`)
+      if (!res.ok) throw new Error('Error al generar QR')
+      const blob = await res.blob()
+      setQrImage(URL.createObjectURL(blob))
+    } catch (err) {
+      alert(err.message)
+    }
+  }
+
   return (
     <>
       <ConserjeNavbar />
@@ -60,6 +72,15 @@ export default function PaquetesCustodia() {
             <div className="container">
               <h2 className="mb-4 text-white">Paquetes en Custodia</h2>
               {error && <div className="alert alert-danger">{error}</div>}
+              {qrImage && (
+                <div className="mb-3 text-center">
+                  <img src={qrImage} alt="QR" />
+                  <button
+                    className="btn btn-link d-block"
+                    onClick={() => setQrImage('')}
+                  >Cerrar QR</button>
+                </div>
+              )}
 
               <div className="card shadow-2-strong" style={{ backgroundColor: '#f5f7fa' }}>
                 <div className="card-body">
@@ -98,6 +119,14 @@ export default function PaquetesCustodia() {
                                 className="btn btn-success btn-sm me-2"
                                 onClick={() => handleEntregar(pkg.id)}
                               >Entregar</button>
+                              <button
+                                className="btn btn-secondary btn-sm me-2"
+                                onClick={() => handleShowQr(pkg.id, 'agregar')}
+                              >QR agregar</button>
+                              <button
+                                className="btn btn-secondary btn-sm me-2"
+                                onClick={() => handleShowQr(pkg.id, 'retirar')}
+                              >QR retirar</button>
                               <button
                                 className="btn btn-danger btn-sm px-3"
                                 onClick={() => handleDelete(pkg.id)}

--- a/client/src/pages/PaquetesResidente.jsx
+++ b/client/src/pages/PaquetesResidente.jsx
@@ -15,6 +15,7 @@ function getDeptoFromToken() {
 export default function PaquetesResidente() {
   const [paquetes, setPaquetes] = useState([]);
   const [error,    setError]    = useState('');
+  const [qrImage,  setQrImage]  = useState('');
   const depto = getDeptoFromToken();          // ej. "101A"
 
   /*──────────── fetch filtrado por depto ────────────*/
@@ -31,6 +32,17 @@ export default function PaquetesResidente() {
       .catch(err => setError(err.message));
   }, [depto]);
 
+  const handleShowQr = async (id) => {
+    try {
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/api/v1/paquetes/${id}/qr/retirar`);
+      if (!res.ok) throw new Error('Error al generar QR');
+      const blob = await res.blob();
+      setQrImage(URL.createObjectURL(blob));
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
   /*──────────────────────── render ────────────────────────*/
   return (
     <>
@@ -45,6 +57,12 @@ export default function PaquetesResidente() {
               </h2>
 
               {error && <div className="alert alert-danger">{error}</div>}
+              {qrImage && (
+                <div className="mb-3 text-center">
+                  <img src={qrImage} alt="QR" />
+                  <button className="btn btn-link d-block" onClick={() => setQrImage('')}>Cerrar QR</button>
+                </div>
+              )}
 
               <div
                 className="card shadow-2-strong"
@@ -63,6 +81,7 @@ export default function PaquetesResidente() {
                           <th>Urgencia</th>
                           <th>Fecha ingreso</th>
                           <th>Estado</th>
+                          <th>QR</th>
                         </tr>
                       </thead>
 
@@ -77,12 +96,17 @@ export default function PaquetesResidente() {
                             <td>{p.urgencia ? 'Sí' : 'No'}</td>
                             <td>{new Date(p.fecha_ingreso).toLocaleString()}</td>
                             <td>{p.estado}</td>
+                            <td>
+                              <button className="btn btn-secondary btn-sm" onClick={() => handleShowQr(p.id)}>
+                                Ver QR
+                              </button>
+                            </td>
                           </tr>
                         ))}
 
                         {!paquetes.length && !error && (
                           <tr>
-                            <td colSpan="8" className="text-center py-4">
+                            <td colSpan="9" className="text-center py-4">
                               Sin paquetes para mostrar.
                             </td>
                           </tr>

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "pg": "^8.14.1",
     "react-bootstrap": "^2.10.9",
     "twilio": "^5.6.1",
-    "typescript": "^5.1.6"
+    "typescript": "^5.1.6",
+    "qrcode": "^1.5.3"
   },
   "devDependencies": {
     "@eslint/js": "^8.57.1",

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,8 @@ import {
   createPaquete,
   getPaquetes,
   deletePaquete,
-  updatePaqueteEstado
+  updatePaqueteEstado,
+  getPaqueteQr
 } from './controllers/v1/paqueteController.js';
 
 import { Router } from 'express';
@@ -44,5 +45,6 @@ app.get   ('/api/v1/paquetes',     getPaquetes);              // lista (opcional
 app.post  ('/api/v1/paquetes',     createPaquete);            // registrar uno nuevo
 app.delete('/api/v1/paquetes/:id', deletePaquete);            // eliminar / marcar entregado
 app.patch ('/api/v1/paquetes/:id/estado', updatePaqueteEstado); // actualizar estado
+app.get   ('/api/v1/paquetes/:id/qr/:accion', getPaqueteQr);     // generar QR
 
 export default app;

--- a/src/services/qrcode.js
+++ b/src/services/qrcode.js
@@ -1,0 +1,5 @@
+import QRCode from 'qrcode';
+
+export async function generateQR(data) {
+  return QRCode.toDataURL(data);
+}


### PR DESCRIPTION
## Summary
- generar códigos QR en el backend
- exponer endpoint para QR
- mostrar QR en páginas de conserje y residente
- actualizar dependencias

## Testing
- `npm run build` *(falla: falta de dependencias TS)*

------
https://chatgpt.com/codex/tasks/task_e_6846306f865c8329b891bd61d263ed5f