### PR TITLE
Fix public navbar links

### DIFF
--- a/client/src/components/NavBar.jsx
+++ b/client/src/components/NavBar.jsx
@@ -21,16 +21,10 @@ export default function NavBar() {
         <div className="collapse navbar-collapse" id="mainNavbar">
           <ul className="navbar-nav me-auto mb-2 mb-lg-0">
             <li className="nav-item">
-              <Link className="nav-link" to="/dashboard/conserje/custodia">Dashboard</Link>
+              <Link className="nav-link" to="/">Inicio</Link>
             </li>
             <li className="nav-item">
               <Link className="nav-link" to="/register">Registrar paquete</Link>
-            </li>
-            <li className="nav-item">
-              <Link className="nav-link" to="/dashboard/conserje/custodia">Entregar paquete</Link>
-            </li>
-            <li className="nav-item">
-              <Link className="nav-link" to="/dashboard/conserje/custodia">Escanear QR</Link>
             </li>
           </ul>
           <div className="d-flex align-items-center gap-2">


### PR DESCRIPTION
## Summary
- show only public links on the landing page navbar

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849bfcb74248329b6628afd7fe5a0f0