### PR TITLE
Fix navigation after delivering packages

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -12,6 +12,7 @@ import Login from './pages/Login.jsx';
 
 import DashboardResidente from './pages/DashboardResidente.jsx';
 import DashboardConserje from './pages/DashboardConserje.jsx';
+import PaquetesCustodia from './pages/PaquetesCustodia.jsx';
 
 import DashboardConserjeRegister from './pages/DashboardConserjeRegister.jsx';
 import EntregarPaquete from './pages/EntregarPaquete.jsx';
@@ -32,6 +33,7 @@ export default function App() {
         <Route path="/login" element={<Login />} />
         {/* Dashboards */}
         <Route path="/dashboard/conserje" element={<DashboardConserje />} />
+        <Route path="/dashboard/conserje/custodia" element={<PaquetesCustodia />} />
         <Route path="/dashboard/conserje/register" element={<DashboardConserjeRegister />} />
         <Route path="/dashboard/conserje/entregar" element={<EntregarPaquete />} />
 

--- a/client/src/pages/EntregarPaquete.jsx
+++ b/client/src/pages/EntregarPaquete.jsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import ConserjeNavbar from '../components/ConserjeNavbar.jsx';
 import { Html5Qrcode } from 'html5-qrcode';
 
 export default function EntregarPaquete() {
   const [result, setResult] = useState('');
   const [Html5Qrcode, setHtml5Qrcode] = useState(null);
+
+  const navigate = useNavigate();
 
   const [scanning, setScanning] = useState(false);
   const [message, setMessage] = useState('');
@@ -42,6 +45,7 @@ export default function EntregarPaquete() {
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || 'Error al actualizar');
       setMessage(`Paquete #${data.id ?? decodedText} entregado`);
+      navigate('/dashboard/conserje/custodia');
     } catch (err) {
       setMessage(`Error: ${err.message}`);
     }


### PR DESCRIPTION
## Summary
- add missing dashboard route for the concierge
- redirect back to package list after QR scan delivery

## Testing
- `npm run build` *(fails: cannot install deps)*
- `npm --prefix client run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685987e0b82c8329a8d1afa700402a4c